### PR TITLE
Fix typo in error message

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemReader.java
@@ -111,7 +111,7 @@ final class PemReader {
                 safeClose(in);
             }
         } catch (FileNotFoundException e) {
-            throw new KeyException("could not fine key file: " + file);
+            throw new KeyException("could not find key file: " + file);
         }
     }
 


### PR DESCRIPTION
Motivation:

Fix typos in error messages.

Modification:

`could not fine` -> `could not find`
